### PR TITLE
zmiana tłumaczenia terminu accessibility support

### DIFF
--- a/guidelines/terms/20/accessibility-supported.html
+++ b/guidelines/terms/20/accessibility-supported.html
@@ -1,11 +1,10 @@
-<dt><dfn data-lt="obsługujące dostępność|obsługują dostępności|obsługuje dostępności|obsługiwania dostępności|obsługiwany przez dostępność">obsługiwana dostępność</dfn></dt>
+<dt><dfn data-lt="obsługujące dostępność|obsługują dostępności|obsługuje dostępności|obsługiwania dostępności|obsługiwany przez dostępność">wsparcie dostępności</dfn></dt>
 <dd>
 
-  <p>obsługiwana przez <a>technologie wspomagające</a> oraz przez przeglądarki i inne <a>programy użytkownika</a></p>
-  <!--   <p>obsługiwana przez użytkowników <a>technologii wspomagających</a> oraz przez przeglądarki i inne <a>programy użytkownika</a></p> -->
+  <p>wspieranie dostępności przez <a>technologie wspomagające</a> oraz przez przeglądarki inne <a>programy użytkownika</a></p>
 
   <p>
-    Żeby zakwalifikować użycie technologii tworzenia treści internetowych jako obsługiwane przez dostępność, muszą być spełnione oba poniższe warunki:
+    Żeby zakwalifikować użycie technologii tworzenia treści internetowych jako wspierające dostępność, muszą być spełnione oba poniższe warunki:
   </p>
 
   <ol>
@@ -14,6 +13,8 @@
 
       <p>
         <strong><a>Technologia treści internetowych</a> musi współpracować z technologiami wspomagającymi.</strong> Oznacza to, że sposoby wykorzystywania tej technologii zostały przetestowane pod kątem współdziałania z technologiami wspomagającymi i umożliwiają odczytywanie treści w <a>języku naturalnym</a>
+		
+		
       </p>
 
       <p><strong>ORAZ</strong></p>
@@ -31,7 +32,7 @@
         <li>
 
           <p>
-            Taka technologia z założenia jest powszechnie obsługiwana przez programy użytkownika, które również obsługują dostępność (tak jak HTML i CSS);
+            Taka technologia z założenia jest powszechnie w programach użytkownika, które wspierają również dostępność (tak jak HTML i CSS);
           </p>
 
           <p><strong>LUB</strong></p>
@@ -39,7 +40,7 @@
 
         <li>
           <p>
-            Technologia jest obsługiwana za pomocą szeroko rozpowszechnionej wtyczki, która również obsługuje dostępność;
+            Technologia jest obsługiwana za pomocą szeroko rozpowszechnionej wtyczki, która również wspiera dostępność;
           </p>
 
           <p><strong>LUB</strong></p>
@@ -47,7 +48,7 @@
 
         <li>
           <p>
-            Treść strony jest dostępna dla zamkniętych środowisk, takich jak środowisko uniwersyteckie lub sieć korporacyjna, gdzie wymagany przez tę technologię program użytkownika i użyty do treści internetowych także obsługuje dostępność;
+            Treść strony jest dostępna dla zamkniętych środowisk, takich jak środowisko uniwersyteckie lub sieć korporacyjna, gdzie program użytkownika wymagany przez tę technologię i użyty do tworzenia treści internetowych także wspiera dostępność;
           </p>
 
           <p><strong>LUB</strong></p>
@@ -55,7 +56,7 @@
 
         <li>
           <p>
-            Programy użytkownika obsługujące technologię, obsługują dostępność i można je z łatwością pobrać lub zakupić w następujący sposób:
+            Programy użytkownika obsługujące tę technologię, wspierają dostępność i można je z łatwością pobrać lub zakupić w następujący sposób:
           </p>
 
           <ul>
@@ -80,32 +81,24 @@
   </ol>
 
   <p class="note">
-    Grupa Robocza WCAG i W3C nie precyzują ani sposobu, ani poziomu obsługi technologii treści internetowych przez technologie wspomagające, aby móc uznać dane technologie internetowe za obsługujące dostępność. Czytaj więcej: <a href="https://www.w3.org/WAI/WCAG21/Understanding/conformance#support-level">Level of Assistive Technology Support Needed for "Accessibility Support"</a> (Poziom wsparcia technologii wspomagających potrzebny do „obsługi dostępności”).
+    Grupa Robocza WCAG i W3C nie precyzują ani sposobu, ani poziomu wsparcia dla technologii treści internetowych przez technologie wspomagające, aby można uznać dane technologie internetowe za wspierające dostępność. Zobacz: <a href="https://www.w3.org/WAI/WCAG21/Understanding/conformance#support-level">Level of Assistive Technology Support Needed for "Accessibility Support"</a> (Poziom wsparcia technologii wspomagających potrzebny do „wsparcia dostępności”).
   </p>
 
   <p class="note">
-    Technologie internetowe mogą być wykorzystywane, nawet jeśli nie obsługują dostępności, dopóki nie są uwzględniane w ocenie dostępności, a strona jako całość będzie zgodna z wymogami, w tym z <a href="#cc4">Wymogiem zgodności: 4</a>. Użycie technologii obsługujących dostępność oraz <a href="#cc5">Wymogiem zgodności 5. Brak zakłóceń</a>.
+    Technologie internetowe mogą być wykorzystywane, nawet jeśli nie wspierają dostępności, dopóki nie są uwzględniane w ocenie dostępności, a strona jako całość będzie zgodna z wymogami, w tym z <a href="#cc4">Wymogiem zgodności: 4</a>. Użycie technologii obsługujących dostępność oraz <a href="#cc5">Wymogiem zgodności 5. Brak zakłóceń</a>.
   </p>
 
   <p class="note">
-    Kiedy <a>technologia</a> używana jest w sposób obsługujący dostępność, nie oznacza to, że wszystkie jej komponenty i ich użycie będą obsługiwały dostępność. Większość technologii, w tym HTML, nie obsługuje dostępności w co najmniej jednym ze swoich komponentów lub sposobie użycia. Strony są zgodne z wytycznymi WCAG tylko wówczas, kiedy użycie technologii obsługującej dostępność, może być uwzględniane jako podstawa oceny zgodności z WCAG.
+    Gdy <a>technologia</a> używana jest w sposób, który wspiera dostępność, nie oznacza to, że wszystkie jej komponenty i ich użycie będą wspierały dostępność. Większość technologii, w tym HTML, nie wspiera dostępności w co najmniej jednym ze swoich komponentów lub sposobie użycia. Strony są zgodne z wytycznymi WCAG tylko wówczas, kiedy użycie technologii wspierającej dostępność, może być uwzględniane jako podstawa oceny zgodności z WCAG.
   </p>
 
   <p class="note">
-    Opierając się na technologiach tworzenia treści internetowych, które mają wiele wersji, należy określić, która wersja obsługuje dostępność.
+    Jeżeli używamy technologii tworzenia treści internetowych, które mają wiele wersji, należy określić, która wersja wspiera dostępność.
   </p>
 
   <p class="note">
-    Jednym ze sposobów dotarcia przez twórców treści internetowych do zastosowań technologii, które obsługują dostępność, jest zapoznanie się z zestawieniami zastosowań udokumentowanych jako obsługujące dostępność (zobacz: <a href="https://www.w3.org/WAI/WCAG21/Understanding/conformance#documented-lists">Understanding Accessibility-Supported Web Technology Uses</a> - Zrozumieć zastosowania technologii internetowych obsługujących dostępność). Autorzy, firmy, sprzedawcy technologii i inni mogą dokumentować sposoby korzystania z technologii treści internetowych obsługujące dostępność. Jednak dokumentacja wszystkich sposobów i metod zastosowania tych technologii w dokumentacji musiałyby odpowiadać powyższej definicji technologii treści WWW obsługujących dostępność.
+    Jednym ze sposobów na znalezienie zastosowań technologii, które wspierają dostępność, jest zapoznanie się z zestawieniami, które są udokumentowane jako wspierane pod względem dostępności (zobacz: <a href="https://www.w3.org/WAI/WCAG21/Understanding/conformance#documented-lists">Understanding Accessibility-Supported Web Technology Uses</a> - Zrozumieć zastosowania technologii internetowych wspierających dostępność). Autorzy, firmy, sprzedawcy technologii i inni mogą dokumentować sposoby korzystania z technologii treści internetowych wspierające dostępność. Ale wszystkie sposoby wykorzystania technologii wskazane w dokumentacji muszą spełniać powyższą definicję technologii internetowych wspierających.
   </p>
 
 </dd>
 
-<!--
-Web technologies can be used in ways that are not accessibility supported as long
-      as they are not <a>relied upon</a> and the page as a whole meets the conformance requirements, including <a href="#cc4">Conformance Requirement 4</a> and <a href="#cc5">Conformance Requirement 5</a>.
-
-<a>relied upon</a>
-
-Kiedy <a>technologia internetowa</a> używana jest w sposób obsługujący dostępność, nie oznacza to, że wszystkie jej komponenty i ich użycie będą obsługiwały dostępność. Większość technologii, w tym HTML, nie obsługuje dostępności w co najmniej jednym ze swoich komponentów lub sposobie użycia. Strony są zgodne z wytycznymi WCAG tylko wówczas, kiedy użycie technologii obsługującej dostępność, może być uwzględniane jako podstawa oceny zgodności z WCAG.
--->


### PR DESCRIPTION
Zastosowane w tłumaczeniu WCAG 2.1 tłumaczenie terminu "accessibility supported" na "obsługiwana dostępność" nie jest jednoznaczne. Odnosi się do dwóch kontekstów:
- technologii tworzenia treści internetowych, które wspierają dostępność, tzn. oferują rozwiązania, dzięki którym można przygotować i publikować treści w sposób dostępny
- programów użytkownika, technologii wspomagających, które obsługują dostępność, tzn. potrafią  wykonywać czynności, umożliwiające prezentację treści w sposób dostępny  
W Dużym słowniku informatycznym Jacek Szaniawski definiuje 'support' jako: 1. wspierać, zabezpieczać (zapewniać niezbędne środki), 2. wspierać, podtrzymywać, asystować [...], 3. potwierdzać (np. teorię).

Propozycja zmiany ujednoznacznia termin, nie wyklucza użycia słów 'obsługuje', 'obsługiwana' jako synonimów w niektórych kontekstach.
Jeśli propozycja zostanie zaakceptowana, konieczny będzie przegląd wszystkich KS, w których termin jest używany i naniesienie niezbędnych poprawek.
